### PR TITLE
Fix data bloat bug by checking for uint8 type data

### DIFF
--- a/code/manno_getImage.m
+++ b/code/manno_getImage.m
@@ -45,5 +45,10 @@ oo.setDefaultResolution(query.resolution);
 
 im = oo.query(query);
 im = permute(rot90(im.data,2),[2,1,3]);
-nii = make_nii(im);
+
+if isa(im, 'uint8') == 1
+    nii = make_nii(im, [1 1 1], [0 0 0], 2);
+else
+    nii = make_nii(im);
+end
 save_nii(nii, fileOut);


### PR DESCRIPTION
@willgray: I can't confirm that this is actually the cause of the error without running the data in question, but this should fix the concern we had earlier. My question is, if this fixes things, why does `make_nii` _not_ recognize the type of the incoming data usually?

Important: Might the incoming data be RGB?

Per the docs:

> Default will use the data type of 'img' matrix
>             For RGB image, you must specify it to either 128
>             or 511.
